### PR TITLE
Add React PropTypes Validator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-exports.Record = require('./record')
+exports.Record = require('./lib/record')

--- a/lib/record.js
+++ b/lib/record.js
@@ -34,6 +34,18 @@ function Record (options) {
 
   Schema.schema = env.schema[schema.title]
 
+  Schema.PropType = function (props, propName, componentName) {
+    var errors = Schema.validate(props[propName])
+
+    if (errors) {
+      var format = JSON.stringify(errors, null, 0)
+
+      return new Error(propName + ' property of ' + componentName + ' is not a valid ' + schema.title + '. Expected: ' + format)
+    }
+
+    return null
+  }
+
   return Schema
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromanage",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "JSON Schema enforced records.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "test": "npm run lint && istanbul cover _mocha -- -R dot",
     "test:watch": "mocha -w -R dot"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vigetlabs/micromanage"
+  },
   "author": "Nate Hunzaker",
   "license": "MIT",
   "dependencies": {

--- a/test/record.test.js
+++ b/test/record.test.js
@@ -65,4 +65,10 @@ describe('Record', function() {
     assert(result.message.match(/Person/))
   })
 
+  it ('returns null on successful proptype validation', function() {
+    var result = Person.PropType({ person: { name: 'Bill' }}, 'person', 'Component')
+
+    assert.equal(result, null)
+  })
+
 })

--- a/test/record.test.js
+++ b/test/record.test.js
@@ -58,4 +58,11 @@ describe('Record', function() {
     assert.equal(Person.schema, Record.env.schema.Person)
   })
 
+  it ('provides a proptype validation', function() {
+    var result = Person.PropType({ person: { name: 0 }}, 'person', 'Component')
+
+    assert(result.message.match(/Component/))
+    assert(result.message.match(/Person/))
+  })
+
 })


### PR DESCRIPTION
<img width="738" alt="screen shot 2015-12-07 at 4 54 58 pm" src="https://cloud.githubusercontent.com/assets/590904/11640955/804a34ce-9d03-11e5-87d9-daf87a77f40c.png">

Example usage:

```javascript
var Record = require('micromanager').Record

var Person = Record({
    title: 'Person',
    properties: {
        name: 'string'
    }
})

var Profile = React.createClass({
    propTypes: {
        person: Person.PropType
    },
    render() {
        return <p>{ this.props.person.name }</p>
    }

})

<Profile person={{ name: 0 }} /> // person property of Profile is not a valid Person. Expected: {"name":{"type":"string"}}]
```
