### PR TITLE
Allow Null Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This project will not release stable updates until 1.0
 
+## 0.4.0
+
+- Allow null values to be merged, do not merge undefined values
+
 ## 0.3.0
 
 - Assign default prop values to null keys

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -8,7 +8,7 @@ function merge (/* ...objects */) {
 
   for (var i = 0, len = arguments.length; i < len; i++) {
     for (var key in arguments[i]) {
-      if (arguments[i][key] !== null) {
+      if (arguments[i][key] !== undefined) {
         clone[key] = arguments[i][key]
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "micromanage",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "JSON Schema enforced records.",
   "main": "index.js",
   "scripts": {

--- a/test/record.test.js
+++ b/test/record.test.js
@@ -9,6 +9,13 @@ describe('Record', function() {
         type: 'string',
         default: 'Phil'
       },
+      rank: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'null' }
+        ],
+        default: null
+      },
       age: 'number'
     }
   })
@@ -19,12 +26,26 @@ describe('Record', function() {
     assert.equal(person.name, 'Phil')
   })
 
-  it ('assigns defaults given null props', function() {
+  it ('assigns defaults given undefined props', function() {
     var person = Person({
-      name: null
+      name: undefined
     })
 
     assert.equal(person.name, 'Phil')
+  })
+
+  it ('respects null default values', function() {
+    var person = Person()
+
+    assert.equal(person.rank, null)
+  })
+
+  it ('allows null values, if the property type allows it', function() {
+    var person = Person({
+      rank: null
+    })
+
+    assert.equal(person.rank, null)
   })
 
   it ('manages nested properties', function() {

--- a/test/record.test.js
+++ b/test/record.test.js
@@ -41,11 +41,15 @@ describe('Record', function() {
   })
 
   it ('allows null values, if the property type allows it', function() {
-    var person = Person({
-      rank: null
-    })
+    var person = Person({ rank: null })
 
     assert.equal(person.rank, null)
+  })
+
+  it ('does not validate with null values, if the property type is not null', function() {
+    var person = Person({ age: null })
+
+    assert.notEqual(Person.validate(person), null)
   })
 
   it ('manages nested properties', function() {


### PR DESCRIPTION
I have a use case where I have a value that is either `null` or a `string`.

The spec says this is a valid type but [this line](https://github.com/vigetlabs/micromanage/blob/master/lib/merge.js#L11) ensures any properties with null values are never merged into the `Schema`.

What do we do about this? This PR is one interpretation where `merge` ignores properties that are `undefined` but will respect `null`s.

Thoughts?
